### PR TITLE
Feat/improve training descriptions

### DIFF
--- a/.cursor/rules/admin-ui.mdc
+++ b/.cursor/rules/admin-ui.mdc
@@ -29,6 +29,7 @@ alwaysApply: false
 
 - One Madrid calendar day: today until tomorrow has synced WOD HTML, then tomorrow.
 - Rendered via `training_description_html.py` + `static/training-description.css` (sanitized WodBuster HTML).
+- Row header may show `Tienes reserva hoy/mañana a las HH:MM` when a non-cancelled `WodBusterBooking` on that display day matches the training row title (case-insensitive name match via `_attach_reservation_hints` in `views.py`).
 
 ## Templates
 

--- a/.cursor/rules/admin-ui.mdc
+++ b/.cursor/rules/admin-ui.mdc
@@ -25,6 +25,11 @@ alwaysApply: false
 - `POST .../sync-wodbuster-bookings`
 - `POST .../cancel-wodbuster-booking`
 
+## Training descriptions (booking list)
+
+- One Madrid calendar day: today until tomorrow has synced WOD HTML, then tomorrow.
+- Rendered via `training_description_html.py` + `static/training-description.css` (sanitized WodBuster HTML).
+
 ## Templates
 
 - Custom list/edit under `wodbooker/templates/admin/booking/`

--- a/docs/wodbuster-integration.md
+++ b/docs/wodbuster-integration.md
@@ -62,6 +62,15 @@ Common events:
 | `get_athlete_services` | `/api/ui/Master_MisServicios` | `AthleteMonthlyStats` (quota + billing-period cancellations) |
 | `get_athlete_reservations_range` | `/api/ui/Master_MisServicios_Reservas` | `AthleteMonthlyStats` (per calendar month, immutable once cached) |
 
+### Training descriptions (`ClasesDesc`)
+
+- `Descripcion` is stored as **HTML** in `ClassTrainingDescription.description` (not stripped at sync).
+- **Board title** (`training_name`): `<h1>` in `Descripcion` first (e.g. Hybrid), else schedule slot name from `Data`, else pizarra `Nombre`.
+- Admin UI merges live API HTML over stale plain-text DB rows; auto-sync also rewrites legacy plain-text when enabled.
+- Sanitize at display in `training_description_html.py` (headings, div/span, br, strong, u; `canvas` and **Movimientos** section with videos are removed).
+- **Display day**: booking list shows one day in Europe/Madrid — today until tomorrow has at least one description with visible text, then tomorrow only. Both days fetch API when `athlete_id` is set.
+- Legacy plain-text rows (no HTML tags) use a simple header formatter until re-synced.
+
 Requires `user.athlete_id` (set at login from `preferences.aspx`).
 
 ### Attendance metrics (do not confuse)

--- a/wodbooker/__init__.py
+++ b/wodbooker/__init__.py
@@ -132,7 +132,15 @@ csrf.init_app(app)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', '123456790')
 
 # SQLite database (Flask instance folder at project root)
-from .db_path import resolve_database_path, sqlalchemy_sqlite_uri
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+from .db_path import (
+    resolve_database_path,
+    sqlalchemy_sqlite_uri,
+    sqlite_connect_args,
+    apply_sqlite_pragmas,
+)
 app.config['SQLALCHEMY_ECHO'] = False
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['CSRF_ENABLED'] = True
@@ -148,7 +156,15 @@ app_dir = op.realpath(os.path.dirname(__file__))
 database_path = resolve_database_path()
 app.config['DATABASE_FILE'] = database_path
 app.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_sqlite_uri(database_path)
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'connect_args': sqlite_connect_args()}
 logging.info('Using database: %s', database_path)
+
+
+@event.listens_for(Engine, 'connect')
+def _set_sqlite_pragmas(dbapi_connection, _connection_record):
+    import sqlite3
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        apply_sqlite_pragmas(dbapi_connection)
 
 def _migrations_root():
     # app_dir is .../wodbooker (package); project root is one level up (migrations/ lives there)

--- a/wodbooker/booker.py
+++ b/wodbooker/booker.py
@@ -21,6 +21,7 @@ from .exceptions import BookingNotAvailable, InvalidWodBusterResponse, \
     ClassIsFull, LoginError, PasswordRequired, InvalidBox, \
     ClassNotFound, BookingFailed, BookingPenalization, BookingLockedException
 from .models import db, Booking, Event, User, WodBusterBooking, ClassTrainingDescription
+from .db_path import db_commit_with_retry
 import re
 
 # Import high-level logger for important business events
@@ -568,6 +569,73 @@ def is_booking_running(booking: Booking) -> bool:
     return booking.id in __CURRENT_THREADS and __CURRENT_THREADS[booking.id].is_alive()
 
 
+def _merge_training_descriptions_into_db(user, current_date, training_descriptions):
+    """Apply API training description rows to the DB session (caller commits)."""
+    existing_descriptions = {
+        td.id_pizarra: td
+        for td in db.session.query(ClassTrainingDescription).filter_by(
+            user_id=user.id,
+            class_date=current_date,
+        ).all()
+        if td.id_pizarra is not None
+    }
+    training_desc_logger.info(
+        "Found %d existing training descriptions in DB for date %s",
+        len(existing_descriptions), current_date,
+    )
+    found_id_pizarras = set()
+    td_new = 0
+    td_updated = 0
+    for training_info in training_descriptions:
+        training_name = training_info['training_name']
+        id_pizarra = training_info.get('id_pizarra')
+        if id_pizarra is None:
+            logging.warning(
+                "Skipping training description without id_pizarra: %s for date %s",
+                training_name, current_date,
+            )
+            continue
+        found_id_pizarras.add(id_pizarra)
+        if id_pizarra in existing_descriptions:
+            existing = existing_descriptions[id_pizarra]
+            existing.training_name = training_name
+            existing.description = training_info.get('description')
+            existing.fetched_at = datetime.now()
+            td_updated += 1
+            training_desc_logger.info(
+                "Updated training description: %s (id_pizarra: %s) for date %s",
+                training_name, id_pizarra, current_date,
+            )
+        else:
+            db.session.add(ClassTrainingDescription(
+                user_id=user.id,
+                class_date=current_date,
+                training_name=training_name,
+                description=training_info.get('description'),
+                id_pizarra=id_pizarra,
+                fetched_at=datetime.now(),
+            ))
+            td_new += 1
+            training_desc_logger.info(
+                "Created new training description: %s (id_pizarra: %s) for date %s",
+                training_name, id_pizarra, current_date,
+            )
+    deleted_count = 0
+    for id_pizarra, existing_desc in existing_descriptions.items():
+        if id_pizarra not in found_id_pizarras:
+            db.session.delete(existing_desc)
+            deleted_count += 1
+            training_desc_logger.info(
+                "Deleted training description: %s (id_pizarra: %s) for date %s (no longer in API)",
+                existing_desc.training_name, id_pizarra, current_date,
+            )
+    training_desc_logger.info(
+        "Training descriptions sync for date %s: %d new, %d updated, %d deleted",
+        current_date, td_new, td_updated, deleted_count,
+    )
+    return td_new, td_updated, deleted_count
+
+
 def sync_training_descriptions_for_date(user: User, target_date: date, box_url: str = None) -> dict:
     """
     Sync training descriptions for a specific date.
@@ -602,74 +670,19 @@ def sync_training_descriptions_for_date(user: User, target_date: date, box_url: 
         training_descriptions = scraper.get_training_descriptions(box_url, user.athlete_id, target_date)
         training_desc_logger.info("Retrieved %d training descriptions from API for date %s", 
                     len(training_descriptions), target_date)
-        
-        # Get existing training descriptions for this date
-        existing_descriptions = {
-            td.id_pizarra: td
-            for td in db.session.query(ClassTrainingDescription).filter_by(
-                user_id=user.id,
-                class_date=target_date
-            ).all()
-            if td.id_pizarra is not None
+
+        td_new, td_updated, deleted_count = _merge_training_descriptions_into_db(
+            user, target_date, training_descriptions,
+        )
+        db_commit_with_retry(db.session)
+
+        return {
+            'success': True,
+            'new': td_new,
+            'updated': td_updated,
+            'deleted': deleted_count,
+            'errors': [],
         }
-        training_desc_logger.info("Found %d existing training descriptions in DB for date %s", 
-                    len(existing_descriptions), target_date)
-        
-        # Track which training descriptions we found (by id_pizarra)
-        found_id_pizarras = set()
-        new_count = 0
-        updated_count = 0
-        
-        for training_info in training_descriptions:
-            training_name = training_info['training_name']
-            id_pizarra = training_info.get('id_pizarra')
-            
-            # Skip if no id_pizarra (shouldn't happen, but be safe)
-            if id_pizarra is None:
-                logging.warning("Skipping training description without id_pizarra: %s for date %s", 
-                             training_name, target_date)
-                continue
-            
-            found_id_pizarras.add(id_pizarra)
-            
-            if id_pizarra in existing_descriptions:
-                # Update existing training description
-                existing = existing_descriptions[id_pizarra]
-                existing.training_name = training_name  # Update name in case it changed
-                existing.description = training_info.get('description')
-                existing.fetched_at = datetime.now()
-                updated_count += 1
-                training_desc_logger.info("Updated training description: %s (id_pizarra: %s) for date %s", 
-                           training_name, id_pizarra, target_date)
-            else:
-                # Create new training description
-                new_description = ClassTrainingDescription(
-                    user_id=user.id,
-                    class_date=target_date,
-                    training_name=training_name,
-                    description=training_info.get('description'),
-                    id_pizarra=id_pizarra,
-                    fetched_at=datetime.now()
-                )
-                db.session.add(new_description)
-                new_count += 1
-                training_desc_logger.info("Created new training description: %s (id_pizarra: %s) for date %s", 
-                           training_name, id_pizarra, target_date)
-        
-        # Delete training descriptions that are no longer in the API response
-        deleted_count = 0
-        for id_pizarra, existing_desc in existing_descriptions.items():
-            if id_pizarra not in found_id_pizarras:
-                db.session.delete(existing_desc)
-                deleted_count += 1
-                training_desc_logger.info("Deleted training description: %s (id_pizarra: %s) for date %s (no longer in API)", 
-                           existing_desc.training_name, id_pizarra, target_date)
-        
-        db.session.commit()
-        training_desc_logger.info("Training descriptions sync for date %s: %d new, %d updated, %d deleted", 
-                   target_date, new_count, updated_count, deleted_count)
-        
-        return {'success': True, 'new': new_count, 'updated': updated_count, 'deleted': deleted_count, 'errors': []}
     except Exception as e:
         db.session.rollback()
         error_msg = f"Error syncing training descriptions for date {target_date}: {str(e)}"
@@ -759,146 +772,83 @@ def sync_wodbuster_bookings(user: User) -> dict:
             try:
                 logging.info("Processing date %s (day %d of sync range)", current_date, 
                            (current_date - start_date).days + 1)
-                with db.session.begin_nested():
-                    booked_classes = scraper.get_user_booked_classes(box_url, user.athlete_id, current_date)
-                    
-                    # Get existing bookings for this date
-                    existing_bookings = {
-                        wb.class_id: wb 
-                        for wb in db.session.query(WodBusterBooking).filter_by(
+                booked_classes = scraper.get_user_booked_classes(
+                    box_url, user.athlete_id, current_date,
+                )
+                training_descriptions = []
+                if monday <= current_date <= sunday:
+                    training_desc_logger.info(
+                        "Fetching training descriptions for user %s, date %s",
+                        user.email, current_date,
+                    )
+                    training_descriptions = scraper.get_training_descriptions(
+                        box_url, user.athlete_id, current_date,
+                    )
+                else:
+                    training_desc_logger.debug(
+                        "Skipping training descriptions for date %s (outside current week %s to %s)",
+                        current_date, monday, sunday,
+                    )
+                training_desc_logger.info(
+                    "Retrieved %d training descriptions from API for date %s",
+                    len(training_descriptions), current_date,
+                )
+
+                existing_bookings = {
+                    wb.class_id: wb
+                    for wb in db.session.query(WodBusterBooking).filter_by(
+                        user_id=user.id,
+                        class_date=current_date,
+                    ).all()
+                }
+                found_class_ids = set()
+                for class_info in booked_classes:
+                    class_id = class_info['class_id']
+                    class_time = class_info['time']
+                    found_class_ids.add(class_id)
+                    if class_id in existing_bookings:
+                        existing = existing_bookings[class_id]
+                        existing.class_name = class_info.get('class_name')
+                        existing.class_type = class_info.get('class_type')
+                        existing.fetched_at = datetime.now()
+                        existing.is_cancelled = False
+                        updated_count += 1
+                    else:
+                        db.session.add(WodBusterBooking(
                             user_id=user.id,
-                            class_date=current_date
-                        ).all()
-                    }
-                    
-                    # Track which bookings we found in the API response
-                    found_class_ids = set()
-                    
-                    for class_info in booked_classes:
-                        class_id = class_info['class_id']
-                        class_time = class_info['time']
-                        found_class_ids.add(class_id)
-                        
-                        # Check if booking already exists
-                        if class_id in existing_bookings:
-                            # Update existing booking
-                            existing = existing_bookings[class_id]
-                            existing.class_name = class_info.get('class_name')
-                            existing.class_type = class_info.get('class_type')
-                            existing.fetched_at = datetime.now()
-                            existing.is_cancelled = False
-                            updated_count += 1
-                        else:
-                            # Create new booking
-                            new_booking = WodBusterBooking(
-                                user_id=user.id,
-                                class_id=class_id,
-                                class_date=current_date,
-                                class_time=class_time,
-                                class_name=class_info.get('class_name'),
-                                class_type=class_info.get('class_type'),
-                                box_url=box_url,
-                                fetched_at=datetime.now(),
-                                is_cancelled=False
-                            )
-                            db.session.add(new_booking)
-                            new_count += 1
-                    
-                    # Mark bookings as cancelled if they're no longer in the API response
-                    for class_id, existing_booking in existing_bookings.items():
-                        if class_id not in found_class_ids:
-                            existing_booking.is_cancelled = True
-                            existing_booking.fetched_at = datetime.now()
-                            cancelled_count += 1
-                    
-                    # Fetch and store training descriptions for this date
-                    # Always sync training descriptions for the full current week (Monday to Sunday)
-                    # even if bookings sync starts later
-                    try:
-                        if current_date >= monday and current_date <= sunday:
-                            training_desc_logger.info("Fetching training descriptions for user %s, date %s", user.email, current_date)
-                            training_descriptions = scraper.get_training_descriptions(box_url, user.athlete_id, current_date)
-                        else:
-                            training_desc_logger.debug("Skipping training descriptions for date %s (outside current week %s to %s)", 
-                                        current_date, monday, sunday)
-                            training_descriptions = []
-                        training_desc_logger.info("Retrieved %d training descriptions from API for date %s", 
-                                   len(training_descriptions), current_date)
-                        
-                        # Get existing training descriptions for this date
-                        # Use id_pizarra as the key since multiple pizarras can have the same name
-                        existing_descriptions = {
-                            td.id_pizarra: td
-                            for td in db.session.query(ClassTrainingDescription).filter_by(
-                                user_id=user.id,
-                                class_date=current_date
-                            ).all()
-                            if td.id_pizarra is not None  # Only include records with id_pizarra
-                        }
-                        training_desc_logger.info("Found %d existing training descriptions in DB for date %s", 
-                                   len(existing_descriptions), current_date)
-                        
-                        # Track which training descriptions we found (by id_pizarra)
-                        found_id_pizarras = set()
-                        new_count = 0
-                        updated_count = 0
-                        
-                        for training_info in training_descriptions:
-                            training_name = training_info['training_name']
-                            id_pizarra = training_info.get('id_pizarra')
-                            
-                            # Skip if no id_pizarra (shouldn't happen, but be safe)
-                            if id_pizarra is None:
-                                logging.warning("Skipping training description without id_pizarra: %s for date %s", 
-                                             training_name, current_date)
-                                continue
-                            
-                            found_id_pizarras.add(id_pizarra)
-                            
-                            if id_pizarra in existing_descriptions:
-                                # Update existing training description
-                                existing = existing_descriptions[id_pizarra]
-                                existing.training_name = training_name  # Update name in case it changed
-                                existing.description = training_info.get('description')
-                                existing.fetched_at = datetime.now()
-                                updated_count += 1
-                                training_desc_logger.info("Updated training description: %s (id_pizarra: %s) for date %s", 
-                                           training_name, id_pizarra, current_date)
-                            else:
-                                # Create new training description
-                                new_description = ClassTrainingDescription(
-                                    user_id=user.id,
-                                    class_date=current_date,
-                                    training_name=training_name,
-                                    description=training_info.get('description'),
-                                    id_pizarra=id_pizarra,
-                                    fetched_at=datetime.now()
-                                )
-                                db.session.add(new_description)
-                                new_count += 1
-                                training_desc_logger.info("Created new training description: %s (id_pizarra: %s) for date %s", 
-                                           training_name, id_pizarra, current_date)
-                        
-                        # Delete training descriptions that are no longer in the API response
-                        deleted_count = 0
-                        for id_pizarra, existing_desc in existing_descriptions.items():
-                            if id_pizarra not in found_id_pizarras:
-                                db.session.delete(existing_desc)
-                                deleted_count += 1
-                                training_desc_logger.info("Deleted training description: %s (id_pizarra: %s) for date %s (no longer in API)", 
-                                           existing_desc.training_name, id_pizarra, current_date)
-                        
-                        training_desc_logger.info("Training descriptions sync for date %s: %d new, %d updated, %d deleted", 
-                                   current_date, new_count, updated_count, deleted_count)
-                    except Exception as e:
-                        # Log but don't fail the entire sync if training descriptions fail
-                        logging.exception("Error syncing training descriptions for date %s: %s", current_date, str(e))
-                
+                            class_id=class_id,
+                            class_date=current_date,
+                            class_time=class_time,
+                            class_name=class_info.get('class_name'),
+                            class_type=class_info.get('class_type'),
+                            box_url=box_url,
+                            fetched_at=datetime.now(),
+                            is_cancelled=False,
+                        ))
+                        new_count += 1
+                for class_id, existing_booking in existing_bookings.items():
+                    if class_id not in found_class_ids:
+                        existing_booking.is_cancelled = True
+                        existing_booking.fetched_at = datetime.now()
+                        cancelled_count += 1
+
+                try:
+                    _merge_training_descriptions_into_db(
+                        user, current_date, training_descriptions,
+                    )
+                except Exception as e:
+                    logging.exception(
+                        "Error syncing training descriptions for date %s: %s",
+                        current_date, str(e),
+                    )
+
+                db_commit_with_retry(db.session)
             except Exception as e:
+                db.session.rollback()
                 error_msg = f"Error syncing date {current_date}: {str(e)}"
                 logging.exception(error_msg)
                 errors.append(error_msg)
-            
+
             current_date += timedelta(days=1)
         
         # Also sync training descriptions for days before start_date but within current week
@@ -909,65 +859,30 @@ def sync_wodbuster_bookings(user: User) -> dict:
             current_date = monday
             while current_date < start_date:
                 try:
-                    with db.session.begin_nested():
-                        training_desc_logger.info("Fetching training descriptions for user %s, date %s (earlier week day)", 
-                                    user.email, current_date)
-                        training_descriptions = scraper.get_training_descriptions(box_url, user.athlete_id, current_date)
-                        training_desc_logger.info("Retrieved %d training descriptions from API for date %s", 
-                                   len(training_descriptions), current_date)
-                        
-                        # Get existing training descriptions for this date
-                        existing_descriptions = {
-                            td.id_pizarra: td
-                            for td in db.session.query(ClassTrainingDescription).filter_by(
-                                user_id=user.id,
-                                class_date=current_date
-                            ).all()
-                            if td.id_pizarra is not None
-                        }
-                        
-                        # Track which training descriptions we found (by id_pizarra)
-                        found_id_pizarras = set()
-                        
-                        for training_info in training_descriptions:
-                            training_name = training_info['training_name']
-                            id_pizarra = training_info.get('id_pizarra')
-                            
-                            if id_pizarra is None:
-                                logging.warning("Skipping training description without id_pizarra: %s for date %s", 
-                                             training_name, current_date)
-                                continue
-                            
-                            found_id_pizarras.add(id_pizarra)
-                            
-                            if id_pizarra in existing_descriptions:
-                                # Update existing training description
-                                existing = existing_descriptions[id_pizarra]
-                                existing.training_name = training_name
-                                existing.description = training_info.get('description')
-                                existing.fetched_at = datetime.now()
-                            else:
-                                # Create new training description
-                                new_description = ClassTrainingDescription(
-                                    user_id=user.id,
-                                    class_date=current_date,
-                                    training_name=training_name,
-                                    description=training_info.get('description'),
-                                    id_pizarra=id_pizarra,
-                                    fetched_at=datetime.now()
-                                )
-                                db.session.add(new_description)
-                        
-                        # Delete training descriptions that are no longer in the API response
-                        for id_pizarra, existing_desc in existing_descriptions.items():
-                            if id_pizarra not in found_id_pizarras:
-                                db.session.delete(existing_desc)
+                    training_desc_logger.info(
+                        "Fetching training descriptions for user %s, date %s (earlier week day)",
+                        user.email, current_date,
+                    )
+                    training_descriptions = scraper.get_training_descriptions(
+                        box_url, user.athlete_id, current_date,
+                    )
+                    training_desc_logger.info(
+                        "Retrieved %d training descriptions from API for date %s",
+                        len(training_descriptions), current_date,
+                    )
+                    _merge_training_descriptions_into_db(
+                        user, current_date, training_descriptions,
+                    )
+                    db_commit_with_retry(db.session)
                 except Exception as e:
-                    logging.warning("Error syncing training descriptions for date %s: %s", current_date, str(e))
-                
+                    db.session.rollback()
+                    logging.warning(
+                        "Error syncing training descriptions for date %s: %s",
+                        current_date, str(e),
+                    )
+
                 current_date += timedelta(days=1)
-        
-        db.session.commit()
+
         logging.info("Sync completed for user %s: %d new, %d updated, %d cancelled", 
                     user.email, new_count, updated_count, cancelled_count)
         

--- a/wodbooker/db_path.py
+++ b/wodbooker/db_path.py
@@ -18,4 +18,41 @@ def resolve_database_path() -> str:
 
 def sqlalchemy_sqlite_uri(database_path: str) -> str:
     path = op.abspath(database_path).replace('\\', '/')
-    return f'sqlite:///{path}?check_same_thread=False'
+    return f'sqlite:///{path}'
+
+
+def sqlite_connect_args() -> dict:
+    """SQLite driver options (busy_timeout in seconds for lock waits)."""
+    return {'check_same_thread': False, 'timeout': 30}
+
+
+def apply_sqlite_pragmas(dbapi_connection) -> None:
+    """Improve concurrent read/write behaviour for multi-threaded Flask + booker."""
+    cursor = dbapi_connection.cursor()
+    cursor.execute('PRAGMA journal_mode=WAL')
+    cursor.execute('PRAGMA busy_timeout=30000')
+    cursor.execute('PRAGMA synchronous=NORMAL')
+    cursor.close()
+
+
+def db_commit_with_retry(session, *, max_attempts: int = 5, base_delay: float = 0.05) -> None:
+    """Commit with retries when SQLite reports database is locked/busy."""
+    import time
+    from sqlalchemy.exc import OperationalError
+
+    last_exc = None
+    for attempt in range(max_attempts):
+        try:
+            session.commit()
+            return
+        except OperationalError as exc:
+            last_exc = exc
+            session.rollback()
+            msg = str(exc).lower()
+            if 'locked' not in msg and 'busy' not in msg:
+                raise
+            if attempt + 1 >= max_attempts:
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+    if last_exc is not None:
+        raise last_exc

--- a/wodbooker/models.py
+++ b/wodbooker/models.py
@@ -136,7 +136,7 @@ class ClassTrainingDescription(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
     class_date = db.Column(db.Date, nullable=False, index=True)
     training_name = db.Column(db.String(128), nullable=False)  # e.g., "WOD", "CROSSFIT", "OPEN BOX"
-    description = db.Column(db.Text, nullable=True)  # Cleaned text description
+    description = db.Column(db.Text, nullable=True)  # WodBuster HTML from ClasesDesc (sanitized at display)
     id_pizarra = db.Column(db.Integer, nullable=False)  # ID to link with class (required for uniqueness)
     fetched_at = db.Column(db.DateTime, default=datetime.now)
     

--- a/wodbooker/scraper.py
+++ b/wodbooker/scraper.py
@@ -8,6 +8,7 @@ import sseclient
 import cloudscraper
 import pytz
 from bs4 import BeautifulSoup
+from .training_description_html import extract_board_title
 from .exceptions import LoginError, InvalidWodBusterResponse, \
     BookingNotAvailable, ClassIsFull, PasswordRequired, InvalidBox, \
     ClassNotFound, BookingFailed, BookingPenalization, BookingLockedException
@@ -622,39 +623,13 @@ class Scraper():
             logging.exception("Unexpected error fetching booked classes for user %s on date %s", self._user, date)
             return []
 
-    @staticmethod
-    def _clean_html(text: str) -> str:
-        """
-        Clean HTML tags from text, preserving line breaks.
-        :param text: HTML text to clean
-        :return: Cleaned text with line breaks preserved
-        """
-        if not text:
-            return ""
-        
-        # Replace <br> and <br/> with newlines
-        text = re.sub(r'<br\s*/?>', '\n', text, flags=re.IGNORECASE)
-        
-        # Replace </p> with newline
-        text = text.replace('</p>', '\n')
-        
-        # Remove all remaining HTML tags
-        text = re.sub(r'<[^<]+?>', '', text)
-        
-        # Clean up multiple newlines
-        text = re.sub(r'\n\s*\n+', '\n\n', text)
-        
-        # Strip leading/trailing whitespace
-        return text.strip()
-
     def get_training_descriptions(self, box_url: str, athlete_id: str, date: datetime.date) -> list:
         """
         Get training descriptions (ClasesDesc) for a specific date.
         :param box_url: The WodBuster box URL (e.g., https://mayantibox.wodbuster.com)
         :param athlete_id: The athlete ID with dashes (e.g., 4bbb52ac-6228-4194-a7e5-eb258c846adf)
         :param date: The date to fetch training descriptions for
-        :return: List of dictionaries with training description information:
-                 [{'training_name': str, 'description': str, 'id_pizarra': int}, ...]
+        :return: List of dicts: training_name, description (HTML from Descripcion), id_pizarra
         :raises LoginError: If user/password combination fails.
         :raises InvalidWodBusterResponse: If the response from WodBuster is not valid
         :raises RequestException: If a network error occurs
@@ -726,84 +701,31 @@ class Scraper():
             # Process each pizarra (training description)
             for idx, pizarra in enumerate(pizarras):
                 id_pizarra = pizarra.get('IdPizarra')
-                description_html = pizarra.get('Descripcion', '')
-                
-                # Clean HTML from description first to extract training name
-                description_clean = self._clean_html(description_html)
-                
-                # Extract training name from description header (first line usually contains "WodMayanti Box", "MinimalMayanti Box", etc.)
-                training_name = None
-                header_line_removed = False
-                if description_clean:
-                    lines = description_clean.split('\n')
-                    first_line = lines[0].strip() if lines else ''
-                    
-                    training_desc_logger.info("Pizarra %d for date %s: First line of description: '%s'", idx, date, first_line[:100])
-                    
-                    # Look for pattern like "WodMayanti Box", "MinimalMayanti Box", "EnduranceMayanti Box"
-                    # Extract the training type (everything before "Mayanti Box" or similar box name)
-                    box_name_patterns = ['Mayanti Box', 'Box', 'CrossFit']
-                    for box_pattern in box_name_patterns:
-                        if box_pattern in first_line:
-                            # Extract everything before the box name
-                            training_name = first_line.split(box_pattern)[0].strip()
-                            training_desc_logger.info("Extracted training name '%s' from pattern '%s' in first line", training_name, box_pattern)
-                            # Remove the header line from description
-                            lines.pop(0)
-                            # Also remove empty line after header if present
-                            if lines and not lines[0].strip():
-                                lines.pop(0)
-                            description_clean = '\n'.join(lines).strip()
-                            header_line_removed = True
-                            break
-                    
-                    # If no box name pattern found, try to extract from first line
-                    # Common patterns: "Wod", "Minimal", "Endurance" at the start
-                    if not training_name and first_line and not header_line_removed:
-                        # Try to match common training types at the start (more comprehensive patterns)
-                        # Pattern order matters - try most specific first
-                        training_type_patterns = [
-                            r'^(Wod|WOD|Minimal|Endurance|Gymnastics|GAP|Open\s*Box|OpenBox)(?=[A-Z])',  # Training type immediately followed by capital letter (like "WodMayanti" - no space)
-                            r'^(Wod|WOD|Minimal|Endurance|Gymnastics|GAP|Open\s*Box|OpenBox)\s+',  # Training type followed by space
-                            r'^(Wod|WOD|Minimal|Endurance|Gymnastics|GAP|Open\s*Box|OpenBox)$',  # Just the training type
-                        ]
-                        for pattern in training_type_patterns:
-                            match = re.match(pattern, first_line, re.IGNORECASE)
-                            if match:
-                                training_name = match.group(1)
-                                training_desc_logger.info("Extracted training name '%s' using regex pattern '%s' from first line '%s'", 
-                                           training_name, pattern, first_line[:100])
-                                # Remove the header line from description
-                                lines.pop(0)
-                                # Also remove empty line after header if present
-                                if lines and not lines[0].strip():
-                                    lines.pop(0)
-                                description_clean = '\n'.join(lines).strip()
-                                header_line_removed = True
-                                break
-                
-                # Fallback to Data mapping, then Nombre from pizarra
-                if not training_name:
-                    training_name = pizarra_to_class_name.get(id_pizarra) or pizarra.get('Nombre', '')
-                    training_desc_logger.info("Using fallback training name '%s' (from Data mapping: %s, from pizarra Nombre: %s)", 
-                                training_name, 
-                                pizarra_to_class_name.get(id_pizarra),
-                                pizarra.get('Nombre', ''))
-                
-                training_desc_logger.info("Final training_name for pizarra %d (IdPizarra: %s): '%s' (extracted from description: %s)", 
-                            idx, id_pizarra, training_name, 'yes' if header_line_removed else 'no')
-                
-                if training_name:  # Only add if we have a training name
+                description_html = (pizarra.get('Descripcion') or '').strip()
+
+                schedule_name = pizarra_to_class_name.get(id_pizarra) or pizarra.get('Nombre', '')
+                training_name = extract_board_title(description_html, schedule_name)
+
+                training_desc_logger.info(
+                    "Final training_name for pizarra %d (IdPizarra: %s): '%s'",
+                    idx, id_pizarra, training_name,
+                )
+
+                if training_name:
                     training_descriptions.append({
                         'training_name': training_name,
-                        'description': description_clean,
-                        'id_pizarra': id_pizarra
+                        'description': description_html,
+                        'id_pizarra': id_pizarra,
                     })
-                    training_desc_logger.info("Added training description: %s (id_pizarra: %s, description length: %d)", 
-                                training_name, id_pizarra, len(description_clean))
+                    training_desc_logger.info(
+                        "Added training description: %s (id_pizarra: %s, description length: %d)",
+                        training_name, id_pizarra, len(description_html),
+                    )
                 else:
-                    training_desc_logger.warning("Skipping pizarra %d for date %s: no training name (IdPizarra: %s)", 
-                                  idx, date, id_pizarra)
+                    training_desc_logger.warning(
+                        "Skipping pizarra %d for date %s: no training name (IdPizarra: %s)",
+                        idx, date, id_pizarra,
+                    )
             
             training_desc_logger.info("Found %d training descriptions for user %s on date %s: %s", 
                         len(training_descriptions), self._user, date, 

--- a/wodbooker/static/training-description.css
+++ b/wodbooker/static/training-description.css
@@ -1,3 +1,47 @@
+/* Entrenos del día row headers */
+.training-desc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+.training-desc-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.training-desc-reservation-hint {
+  flex: 0 1 auto;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #b45309;
+  text-align: right;
+  white-space: nowrap;
+  max-width: 55%;
+  line-height: 1.25;
+}
+
+@media (max-width: 576px) {
+  .training-desc-header {
+    gap: 0.35rem;
+    align-items: flex-start;
+  }
+
+  .training-desc-title {
+    font-size: 0.9rem !important;
+  }
+
+  .training-desc-reservation-hint {
+    font-size: 0.75rem;
+    max-width: 48%;
+    margin-right: 0.5rem;
+    line-height: 1.2;
+    padding-top: 0.2rem;
+  }
+}
+
 /* WodBuster-style training board (light admin theme) */
 .wod-training-description {
   color: #1e293b;

--- a/wodbooker/static/training-description.css
+++ b/wodbooker/static/training-description.css
@@ -1,0 +1,65 @@
+/* WodBuster-style training board (light admin theme) */
+.wod-training-description {
+  color: #1e293b;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.wod-training-description h1 {
+  display: none;
+}
+
+.wod-training-description h2 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #0f172a;
+  margin: 1rem 0 0.5rem;
+  padding: 0;
+}
+
+.wod-training-description h2:first-child {
+  margin-top: 0;
+}
+
+.wod-training-description div {
+  margin-bottom: 0.35rem;
+}
+
+.wod-training-description span[style*="underline"],
+.wod-training-description u {
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.wod-training-description strong {
+  font-weight: 600;
+}
+
+.wod-training-description .movimientos {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.wod-training-description .movimientos h2 {
+  margin-bottom: 0.75rem;
+}
+
+.wod-training-description .flex-video {
+  margin: 0.5rem auto 1rem;
+  max-width: 560px;
+}
+
+.wod-training-description .flex-video iframe {
+  display: block;
+  width: 100%;
+  max-width: 560px;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  border-radius: 6px;
+}
+
+.wod-training-description canvas.bmc {
+  display: none;
+}

--- a/wodbooker/templates/admin/booking/list.html
+++ b/wodbooker/templates/admin/booking/list.html
@@ -106,6 +106,50 @@
     </div>
   </div>
   {% endif %}
+  {% if training_display_date and training_descriptions is defined %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='training-description.css') }}">
+    <div class="mt-3 mb-3">
+      <h3 style="font-size: 1.25rem; font-weight: 600; color: #1e293b; margin-bottom: 1rem;">
+        <i class="bi bi-list-ul me-2"></i> Entrenos del día
+      </h3>
+      <div class="accordion" id="trainingDescriptionsAccordion">
+        {% set desc_dow = training_display_date.weekday() %}
+        <div class="weekday-header" style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #fcd34d; border-radius: 8px; padding: 0.5rem 1rem; margin-bottom: 0.5rem; font-weight: 600; color: #92400e; font-size: 1rem;">
+          <span>{{ DAYS_OF_WEEK[desc_dow] }} {{ training_display_date.strftime('%d/%m/%Y') }}</span>
+        </div>
+        {% for desc in training_descriptions %}
+          {% set has_description = desc.formatted_description %}
+          {% set desc_id = desc.id if desc.id is defined and desc.id else ('temp_' + loop.index0|string) %}
+          <div class="card" style="margin-bottom: {% if loop.index0 > 0 %}0.25rem{% else %}0.5rem{% endif %}; border-left: 4px solid #f59e0b;">
+            <div class="card-header" id="headingTD{{desc_id}}" style="padding: 0.5rem 1rem; background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);">
+              <h2 class="mb-0" style="margin-bottom: 0; width: 100%;">
+                {% if has_description %}
+                  <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseTD{{desc_id}}" aria-expanded="false" aria-controls="collapseTD{{desc_id}}" style="padding: 0; text-decoration: none; width: 100%; text-align: left;">
+                    <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
+                      {{ desc.display_title or desc.training_name }}
+                    </h4>
+                  </button>
+                {% else %}
+                  <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
+                    {{ desc.display_title or desc.training_name }} - Aún no hay el entreno disponible
+                  </h4>
+                {% endif %}
+              </h2>
+            </div>
+            {% if has_description %}
+              <div id="collapseTD{{desc_id}}" class="collapse" aria-labelledby="headingTD{{desc_id}}" data-parent="#trainingDescriptionsAccordion">
+                <div class="card-body" style="padding: 0.75rem 1rem;">
+                  <div class="wod-training-description">
+                    {{ desc.formatted_description|safe }}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 {% block model_list_table %}
   {% if not data %}
@@ -282,61 +326,6 @@
               </div>
             </div>
           </div>
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
-  
-  {% if training_descriptions_by_date %}
-    <div class="mt-4">
-      <h3 style="font-size: 1.25rem; font-weight: 600; color: #1e293b; margin-bottom: 1rem;">
-        <i class="bi bi-list-ul me-2"></i> Entrenos del día
-      </h3>
-      <div class="accordion" id="trainingDescriptionsAccordion">
-        {% for desc_date, descriptions in training_descriptions_by_date %}
-          {% set desc_dow = desc_date.weekday() %}
-          <div class="weekday-header" style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #fcd34d; border-radius: 8px; padding: 0.5rem 1rem; margin-bottom: 0.5rem; margin-top: 0.75rem; font-weight: 600; color: #92400e; font-size: 1rem;">
-            <span>{{ DAYS_OF_WEEK[desc_dow] }} {{ desc_date.strftime('%d/%m/%Y') }}</span>
-          </div>
-          {% for desc in descriptions %}
-            {% set is_same_date_as_prev = loop.index0 > 0 %}
-            {% set has_description = desc.formatted_description or desc.description %}
-            {% set desc_id = desc.id if desc.id is defined and desc.id else ('temp_' + loop.index0|string) %}
-            <div class="card" style="margin-bottom: {% if is_same_date_as_prev %}0.25rem{% else %}0.5rem{% endif %}; border-left: 4px solid #f59e0b;">
-              <div class="card-header" id="headingTD{{desc_id}}" style="padding: 0.5rem 1rem; background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);">
-                <h2 class="mb-0" style="margin-bottom: 0; width: 100%;">
-                  {% if has_description %}
-                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseTD{{desc_id}}" aria-expanded="false" aria-controls="collapseTD{{desc_id}}" style="padding: 0; text-decoration: none; width: 100%; text-align: left;">
-                      <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
-                        {{ desc.training_name }}
-                      </h4>
-                    </button>
-                  {% else %}
-                    <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
-                      {{ desc.training_name }} - Aún no hay el entreno disponible
-                    </h4>
-                  {% endif %}
-                </h2>
-              </div>
-              {% if has_description %}
-                <div id="collapseTD{{desc_id}}" class="collapse" aria-labelledby="headingTD{{desc_id}}" data-parent="#trainingDescriptionsAccordion">
-                  <div class="card-body" style="padding: 0.75rem 1rem;">
-                    <div class="container-fluid" style="padding: 0;">
-                      {% if desc.formatted_description %}
-                        <div style="white-space: pre-wrap; color: #1e293b; line-height: 1.2; margin: 0; padding: 0;">
-                          {{ desc.formatted_description|safe }}
-                        </div>
-                      {% elif desc.description %}
-                        <div style="white-space: pre-wrap; color: #1e293b; line-height: 1.2; margin: 0; padding: 0;">
-                          {{ desc.description }}
-                        </div>
-                      {% endif %}
-                    </div>
-                  </div>
-                </div>
-              {% endif %}
-            </div>
-          {% endfor %}
         {% endfor %}
       </div>
     </div>

--- a/wodbooker/templates/admin/booking/list.html
+++ b/wodbooker/templates/admin/booking/list.html
@@ -109,13 +109,10 @@
   {% if training_display_date and training_descriptions is defined %}
     <link rel="stylesheet" href="{{ url_for('static', filename='training-description.css') }}">
     <div class="mt-3 mb-3">
-      <h3 style="font-size: 1.25rem; font-weight: 600; color: #1e293b; margin-bottom: 1rem;">
-        <i class="bi bi-list-ul me-2"></i> Entrenos del día
-      </h3>
       <div class="accordion" id="trainingDescriptionsAccordion">
         {% set desc_dow = training_display_date.weekday() %}
         <div class="weekday-header" style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #fcd34d; border-radius: 8px; padding: 0.5rem 1rem; margin-bottom: 0.5rem; font-weight: 600; color: #92400e; font-size: 1rem;">
-          <span>{{ DAYS_OF_WEEK[desc_dow] }} {{ training_display_date.strftime('%d/%m/%Y') }}</span>
+          <span>Entrenos del día - {{ DAYS_OF_WEEK[desc_dow] }} {{ training_display_date.strftime('%d/%m/%Y') }}</span>
         </div>
         {% for desc in training_descriptions %}
           {% set has_description = desc.formatted_description %}
@@ -125,14 +122,24 @@
               <h2 class="mb-0" style="margin-bottom: 0; width: 100%;">
                 {% if has_description %}
                   <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseTD{{desc_id}}" aria-expanded="false" aria-controls="collapseTD{{desc_id}}" style="padding: 0; text-decoration: none; width: 100%; text-align: left;">
-                    <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
-                      {{ desc.display_title or desc.training_name }}
-                    </h4>
+                    <div class="training-desc-header">
+                      <h4 class="training-desc-title" style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
+                        {{ desc.display_title or desc.training_name }}
+                      </h4>
+                      {% if desc.reservation_hint %}
+                        <span class="training-desc-reservation-hint">{{ desc.reservation_hint }}</span>
+                      {% endif %}
+                    </div>
                   </button>
                 {% else %}
-                  <h4 style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
-                    {{ desc.display_title or desc.training_name }} - Aún no hay el entreno disponible
-                  </h4>
+                  <div class="training-desc-header">
+                    <h4 class="training-desc-title" style="margin-bottom: 0.25rem; font-size: 1rem; font-weight: 600; color: #92400e; text-align: left;">
+                      {{ desc.display_title or desc.training_name }} - Aún no hay el entreno disponible
+                    </h4>
+                    {% if desc.reservation_hint %}
+                      <span class="training-desc-reservation-hint">{{ desc.reservation_hint }}</span>
+                    {% endif %}
+                  </div>
                 {% endif %}
               </h2>
             </div>

--- a/wodbooker/training_description_html.py
+++ b/wodbooker/training_description_html.py
@@ -1,0 +1,183 @@
+"""Sanitize and prepare WodBuster training description HTML for display."""
+import re
+from html import unescape
+
+from bs4 import BeautifulSoup
+
+_ALLOWED_TAGS = frozenset({
+    'h1', 'h2', 'div', 'span', 'p', 'br', 'strong', 'u',
+})
+_STYLE_ALLOWLIST = frozenset({
+    'text-decoration', 'text-align', 'max-width', 'aspect-ratio', 'position',
+})
+_CLASS_ALLOWLIST = frozenset({
+    'text-center', 'movimientos', 'flex-video', 'widescreen', 'bmc',
+})
+_HTML_TAG_RE = re.compile(r'<[a-zA-Z][\w-]*', re.IGNORECASE)
+_MOVIMIENTOS_HEADER_RE = re.compile(r'^movimientos?$|^movements?$', re.IGNORECASE)
+
+
+def description_is_html(text: str) -> bool:
+    """True if text looks like HTML markup (not legacy plain-text cache)."""
+    if not text or not str(text).strip():
+        return False
+    s = str(text).strip()
+    return '<' in s and bool(_HTML_TAG_RE.search(s))
+
+
+def extract_board_title(description_html: str, fallback: str = '') -> str:
+    """Board title from WodBuster <h1> (e.g. Hybrid), else fallback schedule name."""
+    if not description_html or not description_html.strip():
+        return fallback
+    h1 = BeautifulSoup(description_html, 'html.parser').find('h1')
+    if h1:
+        title = h1.get_text(strip=True)
+        if title:
+            return title
+    return fallback
+
+
+def visible_text_len(html_or_text: str) -> int:
+    """Length of visible text after stripping HTML (for empty-content checks)."""
+    if not html_or_text or not html_or_text.strip():
+        return 0
+    if '<' in html_or_text:
+        return len(BeautifulSoup(html_or_text, 'html.parser').get_text(strip=True))
+    return len(html_or_text.strip())
+
+
+def _filter_style(style_value: str) -> str:
+    if not style_value:
+        return ''
+    parts = []
+    for decl in style_value.split(';'):
+        decl = decl.strip()
+        if not decl or ':' not in decl:
+            continue
+        prop, val = decl.split(':', 1)
+        prop = prop.strip().lower()
+        if prop in _STYLE_ALLOWLIST:
+            parts.append(f'{prop}: {val.strip()}')
+    return '; '.join(parts)
+
+
+def _decompose_tag_and_following_siblings(tag) -> None:
+    while tag is not None:
+        sibling = tag.find_next_sibling()
+        tag.decompose()
+        tag = sibling
+
+
+def _tag_classes(tag) -> list:
+    """Return class list from a tag; BS4 may leave attrs as None on some nodes."""
+    attrs = getattr(tag, 'attrs', None)
+    if not attrs:
+        return []
+    raw = attrs.get('class')
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    return [str(raw)]
+
+
+def _strip_movimientos_section(html: str) -> str:
+    """Remove Movimientos block and everything after it (movement videos)."""
+    soup = BeautifulSoup(html, 'html.parser')
+    for div in list(soup.find_all('div')):
+        if any('movimientos' in cls.lower() for cls in _tag_classes(div)):
+            div.decompose()
+    for h2 in list(soup.find_all('h2')):
+        if _MOVIMIENTOS_HEADER_RE.match(h2.get_text(strip=True)):
+            _decompose_tag_and_following_siblings(h2)
+    return ''.join(str(c) for c in soup.children).strip()
+
+
+def _sanitize_element(tag) -> None:
+    if tag.name == 'iframe':
+        tag.decompose()
+        return
+
+    if tag.name == 'canvas':
+        tag.decompose()
+        return
+
+    if tag.name not in _ALLOWED_TAGS:
+        tag.unwrap()
+        return
+
+    attrs = dict(tag.attrs or {})
+    for attr in list(attrs):
+        if attr == 'class':
+            classes = [c for c in _tag_classes(tag) if c in _CLASS_ALLOWLIST]
+            if classes:
+                tag['class'] = classes
+            else:
+                del tag[attr]
+        elif attr == 'style':
+            filtered = _filter_style(tag.get('style', ''))
+            if filtered:
+                tag['style'] = filtered
+            else:
+                del tag[attr]
+        elif attr not in ('href',):
+            del tag[attr]
+
+
+def sanitize_training_html(html: str) -> str:
+    """Return safe HTML subset matching WodBuster workout boards."""
+    if not html or not html.strip():
+        return ''
+
+    html = _strip_movimientos_section(html)
+    soup = BeautifulSoup(html, 'html.parser')
+    for tag in reversed(soup.find_all(True)):
+        _sanitize_element(tag)
+
+    result = ''.join(str(c) for c in soup.children).strip()
+    return unescape(result) if result else ''
+
+
+def _format_legacy_plain_text(text: str) -> str:
+    """Bold likely section headers in old plain-text cached descriptions."""
+    if not text:
+        return ''
+
+    text = unescape(text.replace('&nbsp;', ' '))
+    header_patterns = [
+        r'^WARM\s+UP', r'^WARMUP', r'^STRENGTH', r'^STRENGHT', r'^WOD\s*$',
+        r'^METCON', r'^COOL\s+DOWN', r'^MOBILITY', r'^STRETCH',
+        r'^MOVIMIENTOS', r'^MOVEMENTS', r'^BLOQUE\s+[IVX]+',
+    ]
+    lines = text.split('\n')
+    formatted = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            formatted.append('')
+            continue
+        if re.match(r'^MOVIMIENTOS', stripped, re.IGNORECASE) or re.match(
+            r'^MOVEMENTS', stripped, re.IGNORECASE
+        ):
+            break
+        is_header = any(re.match(p, stripped, re.IGNORECASE) for p in header_patterns)
+        if not is_header and len(stripped) < 40 and stripped.isupper() and len(stripped.split()) <= 6:
+            is_header = True
+        if is_header:
+            formatted.append(
+                f'<strong style="font-size: 1.1em; font-weight: 700;">{stripped}</strong>'
+            )
+        else:
+            formatted.append(stripped)
+    return '<br />\n'.join(formatted)
+
+
+def prepare_training_description(html_or_text: str) -> str | None:
+    """Sanitize WodBuster HTML or format legacy plain text for template |safe."""
+    if not html_or_text or not html_or_text.strip():
+        return None
+    stripped = html_or_text.strip()
+    if description_is_html(stripped):
+        sanitized = sanitize_training_html(stripped)
+        return sanitized or None
+    return _format_legacy_plain_text(stripped) or None

--- a/wodbooker/views.py
+++ b/wodbooker/views.py
@@ -405,100 +405,19 @@ class BookingAdmin(sqla.ModelView):
         kwargs['DAYS_OF_WEEK'] = DAYS_OF_WEEK
         kwargs['weekday_stats'] = getattr(self, '_weekday_stats', {})
         
-        # Map class names to colors (same as weekly_classes route)
-        class_color_map_by_name = {
-            'GAP': '#ec4899',  # pink
-            'ENDURANCE': '#0ea5e9',  # light blue
-        }
-        
-        # Map class type IDs to colors (for fallback)
-        class_color_map_by_id = {
-            1: '#059669',  # green - Wod
-            2: '#000000',  # black - Open Box
-            7: '#000000',  # black - Open Box*
-            9: '#2563eb',  # blue - Gymnastics
-            10: '#be185d',  # dark pink - Teens
-            14: '#64748b',  # gray - Adapted Training
-            17: '#eab308',  # yellow - Minimal
-            18: '#0ea5e9',  # light blue - Endurance
-            19: '#ec4899',  # pink - GAP
-        }
-        
-        # Fetch WodBuster bookings for the current week only
         wodbuster_bookings = []
+        madrid_today = None
         if login.current_user.is_authenticated:
-            from datetime import date, timedelta
-            today = date.today()
-            
-            # Get all WodBuster bookings from today onwards
+            madrid_today = datetime.now(_MADRID_TZ).date()
             bookings = db.session.query(WodBusterBooking).filter(
                 WodBusterBooking.user_id == login.current_user.id,
                 WodBusterBooking.is_cancelled == False,
-                WodBusterBooking.class_date >= today
+                WodBusterBooking.class_date >= madrid_today,
             ).order_by(WodBusterBooking.class_date, WodBusterBooking.class_time).all()
-            
-            # Process bookings to add color information
             for booking in bookings:
-                # Use class_name as the friendly name (it contains the friendly name from Nombre field in JSON)
-                # If class_name is None or empty, try to derive from class_type as fallback
-                if booking.class_name:
-                    friendly_name = booking.class_name
-                elif booking.class_type:
-                    # Fallback: try to map class_type to friendly name
-                    if booking.class_type == 'wod':
-                        friendly_name = 'Wod'
-                    elif booking.class_type == 'openbox':
-                        friendly_name = 'Open Box'
-                    elif booking.class_type.startswith('type_'):
-                        try:
-                            id_e = int(booking.class_type.split('_')[1])
-                            # Map some known IDs
-                            if id_e == 17:
-                                friendly_name = 'Minimal'
-                            elif id_e == 14:
-                                friendly_name = 'Adapted Training'
-                            elif id_e == 10:
-                                friendly_name = 'Teens'
-                            elif id_e == 9:
-                                friendly_name = 'Gymnastics'
-                            elif id_e == 18:
-                                friendly_name = 'Endurance'
-                            elif id_e == 19:
-                                friendly_name = 'GAP'
-                            else:
-                                friendly_name = f'Type {id_e}'
-                        except (ValueError, IndexError):
-                            friendly_name = booking.class_type
-                    else:
-                        friendly_name = booking.class_type
-                else:
-                    friendly_name = 'N/A'
-                
-                # Get color: first check by name (uppercase), then try to extract ID from class_type
-                friendly_name_upper = friendly_name.upper()
-                if friendly_name_upper in class_color_map_by_name:
-                    booking.badge_color = class_color_map_by_name[friendly_name_upper]
-                else:
-                    # Try to extract ID from class_type (e.g., 'type_18' -> 18, 'wod' -> 1, 'openbox' -> 2)
-                    id_e = None
-                    if booking.class_type:
-                        if booking.class_type == 'wod':
-                            id_e = 1
-                        elif booking.class_type == 'openbox':
-                            id_e = 2
-                        elif booking.class_type.startswith('type_'):
-                            try:
-                                id_e = int(booking.class_type.split('_')[1])
-                            except (ValueError, IndexError):
-                                pass
-                    
-                    if id_e and id_e in class_color_map_by_id:
-                        booking.badge_color = class_color_map_by_id[id_e]
-                    else:
-                        booking.badge_color = '#64748b'  # default gray
-                
+                friendly_name = _wodbuster_booking_display_name(booking)
                 booking.badge_name = friendly_name
-            
+                booking.badge_color = _wodbuster_booking_badge_color(booking, friendly_name)
             wodbuster_bookings = bookings
         
         kwargs['wodbuster_bookings'] = wodbuster_bookings
@@ -507,7 +426,7 @@ class BookingAdmin(sqla.ModelView):
         kwargs['training_descriptions'] = []
         if login.current_user.is_authenticated:
             user = login.current_user
-            today = datetime.now(pytz.timezone('Europe/Madrid')).date()
+            today = madrid_today or datetime.now(_MADRID_TZ).date()
             tomorrow = today + timedelta(days=1)
 
             training_desc_logger.info(
@@ -550,6 +469,9 @@ class BookingAdmin(sqla.ModelView):
             _apply_formatted_descriptions(training_list)
 
             if training_list:
+                _attach_reservation_hints(
+                    training_list, display_date, today, wodbuster_bookings,
+                )
                 kwargs['training_display_date'] = display_date
                 kwargs['training_descriptions'] = training_list
             training_desc_logger.info(
@@ -802,6 +724,110 @@ class UserView(sqla.ModelView):
 
 _MADRID_TZ = pytz.timezone('Europe/Madrid')
 
+_WODBUSTER_CLASS_COLOR_BY_NAME = {
+    'GAP': '#ec4899',
+    'ENDURANCE': '#0ea5e9',
+}
+
+_WODBUSTER_CLASS_COLOR_BY_ID = {
+    1: '#059669',
+    2: '#000000',
+    7: '#000000',
+    9: '#2563eb',
+    10: '#be185d',
+    14: '#64748b',
+    17: '#eab308',
+    18: '#0ea5e9',
+    19: '#ec4899',
+}
+
+
+def _wodbuster_booking_display_name(booking) -> str:
+    if booking.class_name:
+        return booking.class_name
+    if booking.class_type:
+        if booking.class_type == 'wod':
+            return 'Wod'
+        if booking.class_type == 'openbox':
+            return 'Open Box'
+        if booking.class_type.startswith('type_'):
+            try:
+                id_e = int(booking.class_type.split('_')[1])
+            except (ValueError, IndexError):
+                return booking.class_type
+            type_names = {
+                17: 'Minimal',
+                14: 'Adapted Training',
+                10: 'Teens',
+                9: 'Gymnastics',
+                18: 'Endurance',
+                19: 'GAP',
+            }
+            return type_names.get(id_e, f'Type {id_e}')
+        return booking.class_type
+    return 'N/A'
+
+
+def _wodbuster_booking_badge_color(booking, friendly_name: str) -> str:
+    friendly_name_upper = friendly_name.upper()
+    if friendly_name_upper in _WODBUSTER_CLASS_COLOR_BY_NAME:
+        return _WODBUSTER_CLASS_COLOR_BY_NAME[friendly_name_upper]
+    id_e = None
+    if booking.class_type:
+        if booking.class_type == 'wod':
+            id_e = 1
+        elif booking.class_type == 'openbox':
+            id_e = 2
+        elif booking.class_type.startswith('type_'):
+            try:
+                id_e = int(booking.class_type.split('_')[1])
+            except (ValueError, IndexError):
+                pass
+    if id_e and id_e in _WODBUSTER_CLASS_COLOR_BY_ID:
+        return _WODBUSTER_CLASS_COLOR_BY_ID[id_e]
+    return '#64748b'
+
+
+def _normalize_training_label(label: str) -> str:
+    return (label or '').strip().casefold()
+
+
+def _format_reservation_times(times) -> str:
+    return ' y '.join(t.strftime('%H:%M') for t in sorted(times))
+
+
+def _attach_reservation_hints(training_list, display_date, madrid_today, bookings):
+    tomorrow = madrid_today + timedelta(days=1)
+    if display_date == madrid_today:
+        day_word = 'hoy'
+    elif display_date == tomorrow:
+        day_word = 'mañana'
+    else:
+        day_word = None
+
+    day_bookings = [
+        b for b in bookings
+        if b.class_date == display_date and not b.is_cancelled
+    ]
+
+    for desc in training_list:
+        desc.reservation_hint = None
+        if not day_word:
+            continue
+        label = _normalize_training_label(desc.display_title or desc.training_name)
+        if not label:
+            continue
+        matching_times = []
+        for booking in day_bookings:
+            booking_label = _normalize_training_label(
+                booking.badge_name or _wodbuster_booking_display_name(booking),
+            )
+            if booking_label == label:
+                matching_times.append(booking.class_time)
+        if matching_times:
+            times_str = _format_reservation_times(matching_times)
+            desc.reservation_hint = f'Tienes reserva {day_word} a las {times_str}'
+
 
 class _TempTrainingDesc:
     """Stand-in for ClassTrainingDescription when only API data exists."""
@@ -812,6 +838,7 @@ class _TempTrainingDesc:
         self.id_pizarra = id_pizarra
         self.formatted_description = None
         self.display_title = None
+        self.reservation_hint = None
         self.class_date = class_date
         self.id = -id_pizarra if id_pizarra else None
 
@@ -958,6 +985,7 @@ def _apply_formatted_descriptions(descriptions):
             extract_board_title(desc.description or '', '')
             or desc.training_name
         )
+        desc.reservation_hint = None
 
 
 def _get_cookie_expiration_date(cookie):

--- a/wodbooker/views.py
+++ b/wodbooker/views.py
@@ -1,6 +1,5 @@
 import logging
-import re
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from collections import defaultdict
 import pickle
 import requests
@@ -23,6 +22,13 @@ from .attendance_stats import sync_wodbuster_all, get_attendance_dashboard
 from .scraper import refresh_scraper, get_scraper
 from .exceptions import LoginError, InvalidWodBusterResponse, PasswordRequired
 from .constants import EventMessage, DAYS_OF_WEEK, DEFAULT_OFFSETS_BY_DAY
+from .training_description_html import (
+    prepare_training_description,
+    visible_text_len,
+    description_is_html,
+    extract_board_title,
+)
+import pytz
 
 # Training description logger (file-only, no console)
 training_desc_logger = logging.getLogger('training_descriptions')
@@ -497,195 +503,61 @@ class BookingAdmin(sqla.ModelView):
         
         kwargs['wodbuster_bookings'] = wodbuster_bookings
         
-        # Fetch training descriptions for today and tomorrow only
-        training_descriptions_by_date = {}
+        kwargs['training_display_date'] = None
+        kwargs['training_descriptions'] = []
         if login.current_user.is_authenticated:
-            from datetime import date, timedelta
-            today = date.today()
+            user = login.current_user
+            today = datetime.now(pytz.timezone('Europe/Madrid')).date()
             tomorrow = today + timedelta(days=1)
-            
-            training_desc_logger.info("Fetching training descriptions for user %s (ID: %d) for today (%s) and tomorrow (%s)", 
-                        login.current_user.email, login.current_user.id, today, tomorrow)
-            
-            # Get training descriptions from DB for today and tomorrow
+
+            training_desc_logger.info(
+                "Fetching training descriptions for user %s (ID: %d) for today (%s) and tomorrow (%s)",
+                user.email, user.id, today, tomorrow,
+            )
+
             descriptions = db.session.query(ClassTrainingDescription).filter(
-                ClassTrainingDescription.user_id == login.current_user.id,
-                ClassTrainingDescription.class_date.in_([today, tomorrow])
-            ).order_by(ClassTrainingDescription.class_date, ClassTrainingDescription.training_name).all()
-            
-            training_desc_logger.info("Found %d training descriptions in DB for user %s (today and tomorrow)", 
-                        len(descriptions), login.current_user.email)
-            
-            # Group by date - create a dict mapping id_pizarra -> description for easy lookup
+                ClassTrainingDescription.user_id == user.id,
+                ClassTrainingDescription.class_date.in_([today, tomorrow]),
+            ).order_by(
+                ClassTrainingDescription.class_date,
+                ClassTrainingDescription.training_name,
+            ).all()
+
+            training_desc_logger.info(
+                "Found %d training descriptions in DB for user %s (today and tomorrow)",
+                len(descriptions), user.email,
+            )
+
             db_descriptions_by_date = {}
-            db_descriptions_by_pizarra = {}  # For tomorrow: id_pizarra -> description object
+            db_by_pizarra = {today: {}, tomorrow: {}}
             for desc in descriptions:
-                if desc.class_date not in db_descriptions_by_date:
-                    db_descriptions_by_date[desc.class_date] = []
-                db_descriptions_by_date[desc.class_date].append(desc)
-                if desc.class_date == tomorrow:
-                    db_descriptions_by_pizarra[desc.id_pizarra] = desc
-            
-            # For today, use all descriptions from DB
-            if today in db_descriptions_by_date:
-                training_descriptions_by_date[today] = db_descriptions_by_date[today]
-            
-            # For tomorrow, fetch available training types from API and merge with DB descriptions
-            if login.current_user.athlete_id:
-                try:
-                    # Get box URL from user's most recent booking
-                    box_url = None
-                    last_booking = db.session.query(Booking).filter_by(user_id=login.current_user.id).order_by(Booking.id.desc()).first()
-                    if last_booking and last_booking.url:
-                        box_url = last_booking.url
-                    else:
-                        scraper = get_scraper(login.current_user.email, login.current_user.cookie)
-                        box_url = scraper.get_box_url()
-                    
-                    if box_url:
-                        scraper = get_scraper(login.current_user.email, login.current_user.cookie)
-                        api_training_types = scraper.get_training_descriptions(box_url, login.current_user.athlete_id, tomorrow)
-                        
-                        training_desc_logger.info("Fetched %d training types from API for tomorrow (%s)", 
-                                    len(api_training_types), tomorrow)
-                        
-                        # Create a set of training types from API
-                        tomorrow_descriptions = []
-                        api_training_by_pizarra = {}
-                        for api_training in api_training_types:
-                            id_pizarra = api_training.get('id_pizarra')
-                            training_name = api_training.get('training_name', '')
-                            description = api_training.get('description', '')
-                            
-                            if id_pizarra:
-                                api_training_by_pizarra[id_pizarra] = api_training
-                                
-                                # Check if we have this in DB
-                                if id_pizarra in db_descriptions_by_pizarra:
-                                    # Use DB version (it's more up-to-date)
-                                    desc = db_descriptions_by_pizarra[id_pizarra]
-                                    tomorrow_descriptions.append(desc)
-                                else:
-                                    # Create a temporary object for API-only training type
-                                    class TempDesc:
-                                        def __init__(self, training_name, description, id_pizarra):
-                                            self.training_name = training_name
-                                            self.description = description
-                                            self.id_pizarra = id_pizarra
-                                            self.formatted_description = None
-                                            self.class_date = tomorrow
-                                            # Use negative id_pizarra as temporary ID (DB IDs are positive)
-                                            self.id = -id_pizarra if id_pizarra else None
-                                    
-                                    temp_desc = TempDesc(training_name, description, id_pizarra)
-                                    tomorrow_descriptions.append(temp_desc)
-                                    training_desc_logger.info("Added API-only training type for tomorrow: %s (id_pizarra: %s)", 
-                                                training_name, id_pizarra)
-                        
-                        # Add any DB descriptions that weren't in API (shouldn't happen, but just in case)
-                        for id_pizarra, desc in db_descriptions_by_pizarra.items():
-                            if id_pizarra not in api_training_by_pizarra:
-                                tomorrow_descriptions.append(desc)
-                                training_desc_logger.info("Added DB-only training type for tomorrow: %s (id_pizarra: %s)", 
-                                            desc.training_name, id_pizarra)
-                        
-                        # Check if auto-sync is enabled and if we need to sync missing descriptions
-                        # This check happens AFTER building the list so we can detect training types showing "Aún no hay el entreno disponible"
-                        auto_sync_enabled = login.current_user.auto_sync_training_descriptions
-                        needs_sync = False
-                        
-                        # Check if any training types in the final list are missing descriptions
-                        for desc in tomorrow_descriptions:
-                            # Check if description is None, empty, or empty after stripping
-                            if not desc.description or not desc.description.strip():
-                                needs_sync = True
-                                training_desc_logger.info("Found training type '%s' without description, will trigger auto-sync", desc.training_name)
-                                break
-                        
-                        # Auto-sync if enabled and needed
-                        if auto_sync_enabled and needs_sync:
-                            training_desc_logger.info("Auto-syncing training descriptions for tomorrow (%s) - user has auto-sync enabled", tomorrow)
-                            try:
-                                sync_result = sync_training_descriptions_for_date(login.current_user, tomorrow, box_url)
-                                if sync_result['success']:
-                                    training_desc_logger.info("Auto-sync completed for tomorrow: %d new, %d updated", 
-                                                sync_result['new'], sync_result['updated'])
-                                    # Refresh DB descriptions after sync
-                                    refreshed_descriptions = db.session.query(ClassTrainingDescription).filter(
-                                        ClassTrainingDescription.user_id == login.current_user.id,
-                                        ClassTrainingDescription.class_date == tomorrow
-                                    ).all()
-                                    # Update our local dict
-                                    db_descriptions_by_pizarra = {
-                                        desc.id_pizarra: desc for desc in refreshed_descriptions
-                                    }
-                                    # Rebuild tomorrow_descriptions with updated data
-                                    tomorrow_descriptions = []
-                                    for api_training in api_training_types:
-                                        id_pizarra = api_training.get('id_pizarra')
-                                        training_name = api_training.get('training_name', '')
-                                        if id_pizarra:
-                                            if id_pizarra in db_descriptions_by_pizarra:
-                                                desc = db_descriptions_by_pizarra[id_pizarra]
-                                                tomorrow_descriptions.append(desc)
-                                            else:
-                                                # Still no DB entry, use API data
-                                                description = api_training.get('description', '')
-                                                class TempDesc:
-                                                    def __init__(self, training_name, description, id_pizarra):
-                                                        self.training_name = training_name
-                                                        self.description = description
-                                                        self.id_pizarra = id_pizarra
-                                                        self.formatted_description = None
-                                                        self.class_date = tomorrow
-                                                        self.id = -id_pizarra if id_pizarra else None
-                                                temp_desc = TempDesc(training_name, description, id_pizarra)
-                                                tomorrow_descriptions.append(temp_desc)
-                                else:
-                                    logging.warning("Auto-sync failed for tomorrow: %s", sync_result.get('errors', []))
-                            except Exception as e:
-                                logging.error("Error during auto-sync for tomorrow: %s", str(e), exc_info=True)
-                        
-                        if tomorrow_descriptions:
-                            training_descriptions_by_date[tomorrow] = tomorrow_descriptions
-                        else:
-                            # No training types available for tomorrow
-                            training_descriptions_by_date[tomorrow] = []
-                            
-                except Exception as e:
-                    logging.error("Error fetching training types from API for tomorrow: %s", str(e), exc_info=True)
-                    # Fallback to DB-only descriptions for tomorrow
-                    if tomorrow in db_descriptions_by_date:
-                        training_descriptions_by_date[tomorrow] = db_descriptions_by_date[tomorrow]
+                db_descriptions_by_date.setdefault(desc.class_date, []).append(desc)
+                if desc.class_date in db_by_pizarra:
+                    db_by_pizarra[desc.class_date][desc.id_pizarra] = desc
+
+            tomorrow_descriptions = _fetch_training_descriptions_for_date(
+                user, tomorrow, db_by_pizarra[tomorrow], db_descriptions_by_date.get(tomorrow),
+            )
+
+            display_date = _pick_training_display_date(today, tomorrow, tomorrow_descriptions)
+            if display_date == tomorrow:
+                training_list = tomorrow_descriptions
             else:
-                # No athlete_id, just use DB descriptions
-                if tomorrow in db_descriptions_by_date:
-                    training_descriptions_by_date[tomorrow] = db_descriptions_by_date[tomorrow]
-            
-            training_desc_logger.info("Grouped training descriptions by date: %d dates with descriptions", 
-                        len(training_descriptions_by_date))
-            for desc_date, descs in training_descriptions_by_date.items():
-                training_desc_logger.info("  Date %s: %d descriptions (%s)", 
-                           desc_date, len(descs), [d.training_name for d in descs])
-            
-            # Format descriptions with bold headers
-            for desc_date, descs in training_descriptions_by_date.items():
-                for desc in descs:
-                    if desc.description:
-                        desc.formatted_description = _format_training_description(desc.description)
-                    else:
-                        desc.formatted_description = None
-            
-            # Convert to sorted list of tuples for easier template iteration
-            training_descriptions_by_date = sorted(training_descriptions_by_date.items())
-            training_desc_logger.info("Final training_descriptions_by_date: %d date entries", 
-                        len(training_descriptions_by_date))
+                training_list = _fetch_training_descriptions_for_date(
+                    user, today, db_by_pizarra[today], db_descriptions_by_date.get(today),
+                )
+
+            _apply_formatted_descriptions(training_list)
+
+            if training_list:
+                kwargs['training_display_date'] = display_date
+                kwargs['training_descriptions'] = training_list
+            training_desc_logger.info(
+                "Display date %s: %d descriptions (%s)",
+                display_date, len(training_list), [d.training_name for d in training_list],
+            )
         else:
             training_desc_logger.warning("User not authenticated, skipping training descriptions fetch")
-        
-        kwargs['training_descriptions_by_date'] = training_descriptions_by_date
-        training_desc_logger.info("Passing training_descriptions_by_date to template: %s", 
-                    "present" if training_descriptions_by_date else "empty")
 
         kwargs['attendance_dashboard'] = None
         if login.current_user.is_authenticated and login.current_user.athlete_id:
@@ -928,6 +800,166 @@ class UserView(sqla.ModelView):
         return count, data
 
 
+_MADRID_TZ = pytz.timezone('Europe/Madrid')
+
+
+class _TempTrainingDesc:
+    """Stand-in for ClassTrainingDescription when only API data exists."""
+
+    def __init__(self, training_name, description, id_pizarra, class_date):
+        self.training_name = training_name
+        self.description = description
+        self.id_pizarra = id_pizarra
+        self.formatted_description = None
+        self.display_title = None
+        self.class_date = class_date
+        self.id = -id_pizarra if id_pizarra else None
+
+
+def _overlay_api_on_db_desc(db_desc, api_training):
+    """Prefer live API HTML over stale plain-text rows still in the DB."""
+    api_description = (api_training.get('description') or '').strip()
+    db_text = (db_desc.description or '').strip()
+    if description_is_html(api_description) and not description_is_html(db_text):
+        db_desc.description = api_description
+        api_name = api_training.get('training_name', '')
+        if api_name:
+            db_desc.training_name = api_name
+        training_desc_logger.info(
+            "Using API HTML for id_pizarra %s (replacing legacy plain-text cache)",
+            db_desc.id_pizarra,
+        )
+    return db_desc
+
+
+def _get_user_box_url(user):
+    last_booking = (
+        db.session.query(Booking)
+        .filter_by(user_id=user.id)
+        .order_by(Booking.id.desc())
+        .first()
+    )
+    if last_booking and last_booking.url:
+        return last_booking.url
+    return get_scraper(user.email, user.cookie).get_box_url()
+
+
+def _merge_descriptions_for_date(target_date, db_by_pizarra, api_training_types):
+    merged = []
+    api_by_pizarra = {}
+    for api_training in api_training_types:
+        id_pizarra = api_training.get('id_pizarra')
+        if not id_pizarra:
+            continue
+        api_by_pizarra[id_pizarra] = api_training
+        if id_pizarra in db_by_pizarra:
+            merged.append(_overlay_api_on_db_desc(db_by_pizarra[id_pizarra], api_training))
+        else:
+            merged.append(_TempTrainingDesc(
+                api_training.get('training_name', ''),
+                api_training.get('description', ''),
+                id_pizarra,
+                target_date,
+            ))
+            training_desc_logger.info(
+                "Added API-only training type for %s: %s (id_pizarra: %s)",
+                target_date, api_training.get('training_name', ''), id_pizarra,
+            )
+    for id_pizarra, desc in db_by_pizarra.items():
+        if id_pizarra not in api_by_pizarra:
+            merged.append(desc)
+            training_desc_logger.info(
+                "Added DB-only training type for %s: %s (id_pizarra: %s)",
+                target_date, desc.training_name, id_pizarra,
+            )
+    return merged
+
+
+def _description_needs_sync(desc) -> bool:
+    text = desc.description
+    if not text or not str(text).strip():
+        return True
+    return not description_is_html(str(text))
+
+
+def _fetch_training_descriptions_for_date(user, target_date, db_by_pizarra, db_list):
+    if not user.athlete_id:
+        return list(db_list or [])
+
+    try:
+        box_url = _get_user_box_url(user)
+    except Exception as e:
+        logging.error("Error resolving box URL for training descriptions: %s", e, exc_info=True)
+        return list(db_list or [])
+
+    if not box_url:
+        return list(db_list or [])
+
+    try:
+        scraper = get_scraper(user.email, user.cookie)
+        api_training_types = scraper.get_training_descriptions(
+            box_url, user.athlete_id, target_date,
+        )
+        training_desc_logger.info(
+            "Fetched %d training types from API for %s",
+            len(api_training_types), target_date,
+        )
+        merged = _merge_descriptions_for_date(target_date, db_by_pizarra, api_training_types)
+
+        needs_sync = any(_description_needs_sync(desc) for desc in merged)
+        if user.auto_sync_training_descriptions and needs_sync:
+            training_desc_logger.info(
+                "Auto-syncing training descriptions for %s (missing or legacy plain-text)",
+                target_date,
+            )
+            try:
+                sync_result = sync_training_descriptions_for_date(user, target_date, box_url)
+                if sync_result['success']:
+                    refreshed = db.session.query(ClassTrainingDescription).filter(
+                        ClassTrainingDescription.user_id == user.id,
+                        ClassTrainingDescription.class_date == target_date,
+                    ).all()
+                    db_by_pizarra = {d.id_pizarra: d for d in refreshed}
+                    merged = _merge_descriptions_for_date(
+                        target_date, db_by_pizarra, api_training_types,
+                    )
+                else:
+                    logging.warning(
+                        "Auto-sync failed for %s: %s", target_date, sync_result.get('errors', []),
+                    )
+            except Exception as e:
+                logging.error("Error during auto-sync for %s: %s", target_date, e, exc_info=True)
+
+        return merged
+    except Exception as e:
+        logging.error(
+            "Error fetching training types from API for %s: %s", target_date, e, exc_info=True,
+        )
+        return list(db_list or [])
+
+
+def _pick_training_display_date(today, tomorrow, tomorrow_descriptions):
+    if any(
+        desc.description and visible_text_len(desc.description) > 0
+        for desc in tomorrow_descriptions
+    ):
+        return tomorrow
+    return today
+
+
+def _apply_formatted_descriptions(descriptions):
+    for desc in descriptions:
+        desc.formatted_description = (
+            prepare_training_description(desc.description)
+            if desc.description
+            else None
+        )
+        desc.display_title = (
+            extract_board_title(desc.description or '', '')
+            or desc.training_name
+        )
+
+
 def _get_cookie_expiration_date(cookie):
     session = cloudscraper.create_scraper()
     session.cookies.update(pickle.loads(cookie))
@@ -937,95 +969,3 @@ def _get_cookie_expiration_date(cookie):
     except (StopIteration, TypeError):
         return None
 
-
-def _format_training_description(text: str) -> str:
-    """
-    Format training description text with bold headers and proper spacing.
-    Headers like "WARM UP", "STRENGTH", "WOD" are made bold.
-    Stops displaying content after "MOVIMIENTOS" section.
-    :param text: Plain text description
-    :return: HTML formatted text with bold headers (content stops at MOVIMIENTOS)
-    """
-    if not text:
-        return ""
-    
-    # Clean HTML entities like &nbsp;
-    text = text.replace('&nbsp;', ' ')
-    # Also handle other common HTML entities
-    text = text.replace('&amp;', '&')
-    text = text.replace('&lt;', '<')
-    text = text.replace('&gt;', '>')
-    text = text.replace('&quot;', '"')
-    
-    # Clean up multiple spaces
-    text = re.sub(r' +', ' ', text)
-    
-    lines = text.split('\n')
-    
-    # Remove excessive empty lines to make text more compact
-    compact_lines = []
-    prev_empty = False
-    for line in lines:
-        is_empty = not line.strip()
-        if is_empty and prev_empty:
-            continue  # Skip consecutive empty lines
-        compact_lines.append(line)
-        prev_empty = is_empty
-    lines = compact_lines
-    
-    formatted_lines = []
-    
-    # Common header patterns (case-insensitive)
-    header_patterns = [
-        r'^WARM\s+UP',
-        r'^WARMUP',
-        r'^ARM\s+UP',  # Handle typo variant
-        r'^STRENGTH',
-        r'^STRENGHT',  # Handle typo variant
-        r'^STRENGTH\s+',
-        r'^WOD\s*$',
-        r'^METCON',
-        r'^COOL\s+DOWN',
-        r'^MOBILITY',
-        r'^STRETCH',
-        r'^MOVIMIENTOS',
-        r'^MOVEMENTS',
-    ]
-    
-    # Stop processing after "MOVIMIENTOS" section
-    stop_after_movimientos = False
-    
-    for i, line in enumerate(lines):
-        original_line = line
-        line = line.strip()
-        if not line:
-            if not stop_after_movimientos:
-                formatted_lines.append('')
-            continue
-        
-        # Check if this is the MOVIMIENTOS section - stop after this
-        if re.match(r'^MOVIMIENTOS', line, re.IGNORECASE):
-            stop_after_movimientos = True
-            # Don't include this line or anything after it
-            break
-        
-        # Check if this line is a header
-        is_header = False
-        for pattern in header_patterns:
-            if re.match(pattern, line, re.IGNORECASE):
-                is_header = True
-                break
-        
-        # Also check if line is all caps and short (likely a header)
-        # More lenient: allow up to 6 words for headers like "COOL DOWN"
-        if not is_header and len(line) < 40 and line.isupper() and len(line.split()) <= 6:
-            is_header = True
-        
-        if is_header:
-            # Don't add extra spacing before header - keep it compact
-            # Make header bold with very compact styling (no margins, tight line-height)
-            formatted_lines.append(f'<strong style="font-size: 1.1em; font-weight: 700; color: #1e293b; display: block; margin: 0; padding: 0; line-height: 1.2;">{line}</strong>')
-        else:
-            formatted_lines.append(line)
-    
-    return '\n'.join(formatted_lines)


### PR DESCRIPTION
The training descriptions were shown unformatted, since the HTML was not parsed properly. Now it should respect the original decorations and keep the formatting clean.

<img width="507" height="534" alt="image" src="https://github.com/user-attachments/assets/8698d896-46c2-4325-b6b9-6f515162fd71" />

In another hand, this section has been moved to the top, and it will show if there is an active booking for any of those trainings:

<img width="514" height="533" alt="image" src="https://github.com/user-attachments/assets/124473d3-5218-4754-befa-9e5e91040521" />

Finally, the header "Entrenos del día" has been removed in order to keep the section more compact and feel less invasive.