### PR TITLE
fix: wrap text in training description header to allow it being cut out

### DIFF
--- a/wodbooker/static/training-description.css
+++ b/wodbooker/static/training-description.css
@@ -1,44 +1,32 @@
 /* Entrenos del día row headers */
 .training-desc-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   width: 100%;
-  gap: 0.75rem;
+  gap: 0.2rem;
 }
 
 .training-desc-title {
-  flex: 1 1 auto;
-  min-width: 0;
+  width: 100%;
 }
 
 .training-desc-reservation-hint {
-  flex: 0 1 auto;
   font-size: 0.85rem;
   font-weight: 500;
   color: #b45309;
-  text-align: right;
-  white-space: nowrap;
-  max-width: 55%;
+  text-align: left;
   line-height: 1.25;
 }
 
 @media (max-width: 576px) {
-  .training-desc-header {
-    gap: 0.35rem;
-    align-items: flex-start;
-  }
-
   .training-desc-title {
     font-size: 0.9rem !important;
   }
 
   .training-desc-reservation-hint {
     font-size: 0.75rem;
-    max-width: 48%;
-    margin-right: 0.5rem;
     line-height: 1.2;
-    padding-top: 0.2rem;
   }
 }
 


### PR DESCRIPTION
Reminders of booked classes in the training description section were cut out in smaller screens. Text will wrap now, fully showing the text:

<img width="343" height="259" alt="image" src="https://github.com/user-attachments/assets/a12f44c2-7076-47d4-8bf7-79320c2a321e" />